### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/src/main/java/org/jackhuang/watercraft/common/block/BlockWaterPower.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/BlockWaterPower.java
@@ -283,7 +283,7 @@ public abstract class BlockWaterPower extends BlockContainer {
                 Block b = world.getBlock(x, y, z);
                 if (tileEntity != null && tileEntity instanceof IDroppable) {
                     IDroppable te = (IDroppable) tileEntity;
-                    ArrayList<ItemStack> drops = b.getDrops(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
+                    List<ItemStack> drops = b.getDrops(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
                     if (b.removedByPlayer(world, entityPlayer, x, y, z, false)) {
                         Utils.dropItems(world, x, y, z, drops);
                     }

--- a/src/main/java/org/jackhuang/watercraft/common/block/reservoir/TileEntityReservoir.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/reservoir/TileEntityReservoir.java
@@ -3,6 +3,7 @@ package org.jackhuang.watercraft.common.block.reservoir;
 import ic2.api.tile.IWrenchable;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -182,35 +183,35 @@ public class TileEntityReservoir extends TileEntityMetaMultiBlock implements IWr
             else
                 break;
 
-        ArrayList<Position> l1 = Reservoir.getNotHorizontalWall(worldObj, xCoord, yCoord, zCoord, length, height, type.ordinal());
+        List<Position> l1 = Reservoir.getNotHorizontalWall(worldObj, xCoord, yCoord, zCoord, length, height, type.ordinal());
         if (l1.size() != 0) {
             size = null;
             lastHeight = lastWidth = lastLength = -1;
             return null;
         }
 
-        ArrayList<Position> l2 = Reservoir.getNotHorizontalWall(worldObj, xCoord, yCoord, zCoord + width - 1, length, height, type.ordinal());
+        List<Position> l2 = Reservoir.getNotHorizontalWall(worldObj, xCoord, yCoord, zCoord + width - 1, length, height, type.ordinal());
         if (l2.size() != 0) {
             size = null;
             lastHeight = lastWidth = lastLength = -1;
             return null;
         }
 
-        ArrayList<Position> l3 = Reservoir.getNotVerticalWall(worldObj, xCoord, yCoord, zCoord, width, height, type.ordinal());
+        List<Position> l3 = Reservoir.getNotVerticalWall(worldObj, xCoord, yCoord, zCoord, width, height, type.ordinal());
         if (l3.size() != 0) {
             size = null;
             lastHeight = lastWidth = lastLength = -1;
             return null;
         }
 
-        ArrayList<Position> l4 = Reservoir.getNotVerticalWall(worldObj, xCoord + length - 1, yCoord, zCoord, width, height, type.ordinal());
+        List<Position> l4 = Reservoir.getNotVerticalWall(worldObj, xCoord + length - 1, yCoord, zCoord, width, height, type.ordinal());
         if (l4.size() != 0) {
             size = null;
             lastHeight = lastWidth = lastLength = -1;
             return null;
         }
 
-        ArrayList<Position> lfloor = Reservoir.getNotFloor(worldObj, xCoord, yCoord, zCoord, length, width, type.ordinal());
+        List<Position> lfloor = Reservoir.getNotFloor(worldObj, xCoord, yCoord, zCoord, length, width, type.ordinal());
         if (lfloor.size() != 0) {
             size = null;
             lastHeight = lastWidth = lastLength = -1;

--- a/src/main/java/org/jackhuang/watercraft/common/block/tileentity/TileEntityMultiBlock.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/tileentity/TileEntityMultiBlock.java
@@ -9,6 +9,7 @@
 package org.jackhuang.watercraft.common.block.tileentity;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -23,7 +24,7 @@ public abstract class TileEntityMultiBlock extends TileEntityLiquidTankInventory
     protected boolean tested;
     private int masterState, masterX, masterY, masterZ;
     private int tick = 0, tick2 = Reference.General.updateTick;
-    protected ArrayList<TileEntityMultiBlock> blockList;
+    protected List<TileEntityMultiBlock> blockList;
 
     public TileEntityMultiBlock(int tankSize) {
         super(tankSize);

--- a/src/main/java/org/jackhuang/watercraft/common/recipe/HashMapRecipeManager.java
+++ b/src/main/java/org/jackhuang/watercraft/common/recipe/HashMapRecipeManager.java
@@ -17,7 +17,7 @@ import net.minecraft.item.ItemStack;
 import org.jackhuang.watercraft.util.StackUtil;
 
 public class HashMapRecipeManager implements IRecipeManager {
-    HashMap<ItemStack, ItemStack> recipes;
+    Map<ItemStack, ItemStack> recipes;
 
     public HashMapRecipeManager(HashMap<ItemStack, ItemStack> recipes) {
         this.recipes = recipes;
@@ -50,7 +50,7 @@ public class HashMapRecipeManager implements IRecipeManager {
 
     @Override
     public Map<IMyRecipeInput, MyRecipeOutput> getAllRecipes() {
-        HashMap<IMyRecipeInput, MyRecipeOutput> map = new HashMap<IMyRecipeInput, MyRecipeOutput>();
+        Map<IMyRecipeInput, MyRecipeOutput> map = new HashMap<IMyRecipeInput, MyRecipeOutput>();
         for (Map.Entry entry : recipes.entrySet()) {
             if (entry.getKey() instanceof ItemStack)
                 map.put(new MyRecipeInputItemStack((ItemStack) entry.getKey()), new MyRecipeOutput((ItemStack) entry.getValue()));

--- a/src/main/java/org/jackhuang/watercraft/common/recipe/MultiRecipeManager.java
+++ b/src/main/java/org/jackhuang/watercraft/common/recipe/MultiRecipeManager.java
@@ -10,12 +10,13 @@ package org.jackhuang.watercraft.common.recipe;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import net.minecraft.item.ItemStack;
 
 public class MultiRecipeManager implements IRecipeManager {
-    ArrayList<IRecipeManager> container = new ArrayList();
+    List<IRecipeManager> container = new ArrayList();
 
     public MultiRecipeManager() {
         addRecipeManager(new MyRecipeManager());
@@ -51,7 +52,7 @@ public class MultiRecipeManager implements IRecipeManager {
 
     @Override
     public Map<IMyRecipeInput, MyRecipeOutput> getAllRecipes() {
-        HashMap map = new HashMap();
+        Map map = new HashMap();
         for (IRecipeManager r : container) {
             map.putAll(r.getAllRecipes());
         }

--- a/src/main/java/org/jackhuang/watercraft/common/recipe/MyRecipeManager.java
+++ b/src/main/java/org/jackhuang/watercraft/common/recipe/MyRecipeManager.java
@@ -11,13 +11,14 @@ package org.jackhuang.watercraft.common.recipe;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import net.minecraft.item.ItemStack;
 
 public class MyRecipeManager implements IRecipeManager {
     private final Map<IMyRecipeInput, MyRecipeOutput> recipes = new HashMap();
-    private ArrayList<HashMap<ItemStack, ItemStack>> singleOutputRecipes = new ArrayList();
+    private List<HashMap<ItemStack, ItemStack>> singleOutputRecipes = new ArrayList();
 
     @Override
     public boolean addRecipe(ItemStack input, ItemStack... outputs) {

--- a/src/main/java/org/jackhuang/watercraft/integration/ic2/IndustrialCraftRecipeManager.java
+++ b/src/main/java/org/jackhuang/watercraft/integration/ic2/IndustrialCraftRecipeManager.java
@@ -58,7 +58,7 @@ public class IndustrialCraftRecipeManager implements IRecipeManager {
 
     @Override
     public Map<IMyRecipeInput, MyRecipeOutput> getAllRecipes() {
-        HashMap<IMyRecipeInput, MyRecipeOutput> map = new HashMap<IMyRecipeInput, MyRecipeOutput>();
+        Map<IMyRecipeInput, MyRecipeOutput> map = new HashMap<IMyRecipeInput, MyRecipeOutput>();
         try {
             for (Map.Entry<IRecipeInput, RecipeOutput> entry : ((IMachineRecipeManager) containsIC2Recipe).getRecipes().entrySet()) {
                 IMyRecipeInput input;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.
