### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/src/main/java/org/jackhuang/watercraft/client/gui/ContainerBase.java
+++ b/src/main/java/org/jackhuang/watercraft/client/gui/ContainerBase.java
@@ -21,7 +21,7 @@ public abstract class ContainerBase extends Container {
     public final ItemStack transferStackInSlot(EntityPlayer player, int sourceSlotIndex) {
         Slot sourceSlot = (Slot) this.inventorySlots.get(sourceSlotIndex);
 
-        if ((sourceSlot != null) && (sourceSlot.getHasStack())) {
+        if (sourceSlot != null && sourceSlot.getHasStack()) {
             ItemStack sourceItemStack = sourceSlot.getStack();
             int oldSourceItemStackSize = sourceItemStack.stackSize;
 

--- a/src/main/java/org/jackhuang/watercraft/common/block/BlockWaterPower.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/BlockWaterPower.java
@@ -108,7 +108,7 @@ public abstract class BlockWaterPower extends BlockContainer {
     public int getDirection(IBlockAccess iBlockAccess, int x, int y, int z) {
         TileEntity te = iBlockAccess.getTileEntity(x, y, z);
 
-        if ((te instanceof TileEntityBlock))
+        if (te instanceof TileEntityBlock)
             return ((TileEntityBlock) te).getDirection();
         int meta = iBlockAccess.getBlockMetadata(x, y, z);
 
@@ -163,7 +163,7 @@ public abstract class BlockWaterPower extends BlockContainer {
 
         TileEntity tileEntity = world.getTileEntity(x, y, z);
 
-        if ((tileEntity instanceof TileEntityBlock)) {
+        if (tileEntity instanceof TileEntityBlock) {
             TileEntityBlock te = (TileEntityBlock) tileEntity;
             if (entityliving == null) {
                 te.setDirection(2);
@@ -202,7 +202,7 @@ public abstract class BlockWaterPower extends BlockContainer {
                 for (int i = 0; i < t.getSizeInventory(); i++) {
                     ItemStack item = t.getStackInSlot(i);
 
-                    if ((item != null) && (item.stackSize > 0)) {
+                    if (item != null && item.stackSize > 0) {
                     	System.out.println("breakBlock: drop item");
                         float rx = Utils.rand.nextFloat() * 0.8F + 0.1F;
                         float ry = Utils.rand.nextFloat() * 0.8F + 0.1F;
@@ -249,7 +249,7 @@ public abstract class BlockWaterPower extends BlockContainer {
     public void onNeighborChange(IBlockAccess world, int x, int y, int z, int tileX, int tileY, int tileZ) {
         TileEntity localTileEntity = world.getTileEntity(x, y, z);
 
-        if ((localTileEntity instanceof TileEntityBase)) {
+        if (localTileEntity instanceof TileEntityBase) {
             ((TileEntityBase) localTileEntity).onNeighborTileChange(tileX, tileY, tileZ);
         }
     }
@@ -297,7 +297,7 @@ public abstract class BlockWaterPower extends BlockContainer {
 
         TileEntity te = world.getTileEntity(x, y, z);
 
-        if ((te instanceof IHasGui)) {
+        if (te instanceof IHasGui) {
             entityPlayer.openGui(WaterPower.instance, ((IHasGui) te).getGuiId(), world, x, y, z);
             return true;
         }

--- a/src/main/java/org/jackhuang/watercraft/common/block/inventory/InventorySlotConsumableLiquid.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/inventory/InventorySlotConsumableLiquid.java
@@ -55,7 +55,7 @@ public class InventorySlotConsumableLiquid extends InventorySlotConsumable {
                         return true;
                     }
                 }
-            } else if ((item instanceof IFluidContainerItem)) {
+            } else if (item instanceof IFluidContainerItem) {
                 containerItem = (IFluidContainerItem) item;
                 FluidStack prevFluid = containerItem.getFluid(stack);
 
@@ -176,7 +176,7 @@ public class InventorySlotConsumableLiquid extends InventorySlotConsumable {
 
             return FluidContainerRegistry.getFluidForFilledItem(filled).amount;
         }
-        if ((stack.getItem() instanceof IFluidContainerItem)) {
+        if (stack.getItem() instanceof IFluidContainerItem) {
             IFluidContainerItem container = (IFluidContainerItem) stack.getItem();
             ItemStack singleStack = StackUtil.copyWithSize(stack, 1);
 

--- a/src/main/java/org/jackhuang/watercraft/common/block/machines/BlockMachines.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/machines/BlockMachines.java
@@ -102,7 +102,7 @@ public class BlockMachines extends BlockWaterPower {
         if (te != null) {
             Class cls = te.getClass();
 
-            if ((te instanceof TileEntityStandardWaterMachine)) {
+            if (te instanceof TileEntityStandardWaterMachine) {
                 TileEntityStandardWaterMachine tem = (TileEntityStandardWaterMachine) te;
                 return (int) Math.floor(tem.getProgress() * 15.0F);
             }

--- a/src/main/java/org/jackhuang/watercraft/common/block/reservoir/BlockReservoir.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/reservoir/BlockReservoir.java
@@ -77,7 +77,7 @@ public class BlockReservoir extends BlockRotor {
         if (current != null) {
             TileEntity tile = world.getTileEntity(x, y, z);
 
-            if ((tile instanceof TileEntityReservoir)) {
+            if (tile instanceof TileEntityReservoir) {
                 TileEntityReservoir reservoir = (TileEntityReservoir) tile;
 
                 if (current.getItem() instanceof ItemReservoir) {
@@ -92,7 +92,7 @@ public class BlockReservoir extends BlockRotor {
                     if (liquid != null) {
                         int qty = reservoir.fill(ForgeDirection.UNKNOWN, liquid, true);
 
-                        if ((qty != 0) && (!entityplayer.capabilities.isCreativeMode)) {
+                        if (qty != 0 && !entityplayer.capabilities.isCreativeMode) {
                             if (current.stackSize > 1) {
                                 if (!entityplayer.inventory.addItemStackToInventory(FluidContainerRegistry.drainFluidContainer(current))) {
                                     entityplayer.dropPlayerItemWithRandomChoice(FluidContainerRegistry.drainFluidContainer(current), false);
@@ -133,7 +133,7 @@ public class BlockReservoir extends BlockRotor {
                             return true;
                         }
                     }
-                } else if ((current.getItem() instanceof IFluidContainerItem)) {
+                } else if (current.getItem() instanceof IFluidContainerItem) {
                     if (current.stackSize != 1) {
                         return false;
                     }
@@ -142,14 +142,14 @@ public class BlockReservoir extends BlockRotor {
                         IFluidContainerItem container = (IFluidContainerItem) current.getItem();
                         FluidStack liquid = container.getFluid(current);
                         FluidStack tankLiquid = reservoir.getFluidStackfromTank();
-                        boolean mustDrain = (liquid == null) || (liquid.amount == 0);
-                        boolean mustFill = (tankLiquid == null) || (tankLiquid.amount == 0);
-                        if ((!mustDrain) || (!mustFill)) {
-                            if ((mustDrain) || (!entityplayer.isSneaking())) {
+                        boolean mustDrain = liquid == null || liquid.amount == 0;
+                        boolean mustFill = tankLiquid == null || tankLiquid.amount == 0;
+                        if (!mustDrain || !mustFill) {
+                            if (mustDrain || !entityplayer.isSneaking()) {
                                 liquid = reservoir.drain(ForgeDirection.UNKNOWN, 1000, false);
                                 int qtyToFill = container.fill(current, liquid, true);
                                 reservoir.drain(ForgeDirection.UNKNOWN, qtyToFill, true);
-                            } else if (((mustFill) || (entityplayer.isSneaking())) && (liquid.amount > 0)) {
+                            } else if ((mustFill || entityplayer.isSneaking()) && liquid.amount > 0) {
                                 int qty = reservoir.fill(ForgeDirection.UNKNOWN, liquid, false);
                                 reservoir.fill(ForgeDirection.UNKNOWN, container.drain(current, qty, true), true);
                             }

--- a/src/main/java/org/jackhuang/watercraft/common/block/tileentity/TileEntityGenerator.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/tileentity/TileEntityGenerator.java
@@ -388,7 +388,7 @@ public abstract class TileEntityGenerator extends TileEntityBlock implements IEn
         if (this.handlerCache != null) {
             this.handlerCache[side] = null;
         }
-        if ((t instanceof IEnergyReceiver)) {
+        if (t instanceof IEnergyReceiver) {
             if (((IEnergyReceiver) t).canConnectEnergy(ForgeDirection.VALID_DIRECTIONS[side])) {
                 if (this.handlerCache == null)
                     this.handlerCache = new IEnergyReceiver[6];


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
