### PR TITLE
 "static" fields should be constant

### DIFF
--- a/src/main/java/org/jackhuang/watercraft/client/gui/DefaultGuiIds.java
+++ b/src/main/java/org/jackhuang/watercraft/client/gui/DefaultGuiIds.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 public final class DefaultGuiIds {
 
-    private static HashMap<String, Integer> idMap = new HashMap<String, Integer>();
+    private static final HashMap<String, Integer> idMap = new HashMap<String, Integer>();
 
     public static int get(String name) {
         if (!idMap.containsKey(name)) {

--- a/src/main/java/org/jackhuang/watercraft/common/block/tileentity/TileEntityGenerator.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/tileentity/TileEntityGenerator.java
@@ -57,7 +57,7 @@ import cpw.mods.fml.relauncher.SideOnly;
         @Interface(iface = "thaumcraft.api.aspects.IAspectContainer", modid = Mods.IDs.Thaumcraft) })
 public abstract class TileEntityGenerator extends TileEntityBlock implements IEnergySource, IHasGui, IKineticSource, IUnitChangeable, IEnergyConnection,
         IChargeConductor, IFluidHandler, IHeatSource, IEssentiaTransport, IAspectContainer {
-    public static Random random = new Random();
+    public static final Random random = new Random();
 
     public double storage = 0.0D;
     public double maxStorage;

--- a/src/main/java/org/jackhuang/watercraft/common/block/turbines/TileEntityTurbine.java
+++ b/src/main/java/org/jackhuang/watercraft/common/block/turbines/TileEntityTurbine.java
@@ -14,7 +14,7 @@ import org.jackhuang.watercraft.util.WPLog;
 
 public class TileEntityTurbine extends TileEntityRotor {
 
-    public static int maxOutput = 32767;
+    public static final int MAX_OUTPUT = 32767;
     // public int speed;
     private TurbineType type;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1444 - “"public static" fields should be constant”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444
Please let me know if you have any questions.
Ayman Abdelghany.
