### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/jackhuang/watercraft/client/gui/DefaultGuiIds.java
+++ b/src/main/java/org/jackhuang/watercraft/client/gui/DefaultGuiIds.java
@@ -6,6 +6,9 @@ public final class DefaultGuiIds {
 
     private static HashMap<String, Integer> idMap = new HashMap<String, Integer>();
 
+    private DefaultGuiIds() {
+    }
+
     public static int get(String name) {
         if (!idMap.containsKey(name)) {
             throw new IllegalArgumentException("default id for " + name + " is not registered.");

--- a/src/main/java/org/jackhuang/watercraft/client/render/RecolorableTextures.java
+++ b/src/main/java/org/jackhuang/watercraft/client/render/RecolorableTextures.java
@@ -22,6 +22,9 @@ public class RecolorableTextures {
     public static final IIconContainer[] CRAFTING = { ItemIcons.PADDLE_BASE, ItemIcons.DRAINAGE_PLATE, ItemIcons.FIXED_FRAME, ItemIcons.FIXED_TOOL,
             ItemIcons.ROTATION_AXLE, ItemIcons.OUTPUT_INTERFACE, ItemIcons.ROTOR, ItemIcons.STATOR, ItemIcons.CASING, ItemIcons.CIRCUIT };
 
+    private RecolorableTextures() {
+    }
+
     public static enum ItemIcons implements IIconContainer {
         INGOT, PLATE, PLATE_DENSE, NUGGET, BLOCK, STICK, GEAR, DUST, DUST_SMALL, DUST_TINY, SCREW, RING, PADDLE_BASE, DRAINAGE_PLATE, FIXED_FRAME, FIXED_TOOL, ROTATION_AXLE, OUTPUT_INTERFACE, ROTOR, STATOR, CASING, CIRCUIT, CRUSHED;
 

--- a/src/main/java/org/jackhuang/watercraft/client/render/RenderUtils.java
+++ b/src/main/java/org/jackhuang/watercraft/client/render/RenderUtils.java
@@ -20,6 +20,9 @@ import cpw.mods.fml.relauncher.SideOnly;
 public final class RenderUtils {
     private static final ResourceLocation BLOCK_TEXTURE = TextureMap.locationBlocksTexture;
 
+    private RenderUtils() {
+    }
+
     public static IIcon getSafeIcon(IIcon icon) {
         if (icon == null)
             return getMissingIcon();

--- a/src/main/java/org/jackhuang/watercraft/common/network/MessagePacketHandler.java
+++ b/src/main/java/org/jackhuang/watercraft/common/network/MessagePacketHandler.java
@@ -10,6 +10,9 @@ public class MessagePacketHandler {
 
     public static final SimpleNetworkWrapper INSTANCE = NetworkRegistry.INSTANCE.newSimpleChannel(Reference.ModName.toLowerCase());
 
+    private MessagePacketHandler() {
+    }
+
     public static void init() {
         int idx = 0;
 

--- a/src/main/java/org/jackhuang/watercraft/common/recipe/MyRecipes.java
+++ b/src/main/java/org/jackhuang/watercraft/common/recipe/MyRecipes.java
@@ -13,4 +13,6 @@ public class MyRecipes {
     public static IRecipeManager centrifuge, sawmill, lathe, implosion;
     public static IRecipeManager macerator, compressor, cutter;
 
+    private MyRecipes() {
+    }
 }

--- a/src/main/java/org/jackhuang/watercraft/common/recipe/RecipeAdder.java
+++ b/src/main/java/org/jackhuang/watercraft/common/recipe/RecipeAdder.java
@@ -29,6 +29,9 @@ import cpw.mods.fml.common.registry.GameRegistry;
 
 public class RecipeAdder {
 
+    private RecipeAdder() {
+    }
+
     public static void lathe(ItemStack input, ItemStack output) {
         MyRecipes.lathe.addRecipe(input, output);
     }

--- a/src/main/java/org/jackhuang/watercraft/integration/ic2/ICItemFinder.java
+++ b/src/main/java/org/jackhuang/watercraft/integration/ic2/ICItemFinder.java
@@ -15,6 +15,9 @@ public class ICItemFinder {
 
     private static Class<?> Ic2Items;
 
+    private ICItemFinder() {
+    }
+
     public static ItemStack getIC2Item(String name) {
         try {
             if (Ic2Items == null)

--- a/src/main/java/org/jackhuang/watercraft/integration/minetweaker/Machines.java
+++ b/src/main/java/org/jackhuang/watercraft/integration/minetweaker/Machines.java
@@ -23,6 +23,9 @@ import stanhebben.zenscript.annotations.ZenMethod;
 @ZenClass("mods.waterpower.Machines")
 public class Machines {
 
+    private Machines() {
+    }
+
     @ZenMethod
     public static void addCrusherRecipe(@NotNull IItemStack input, @NotNull IItemStack output) {
         MineTweakerAPI.apply(new AddRecipeAction("WaterPower Crusher", MyRecipes.macerator, MineTweakerMC.getItemStack(input), MineTweakerMC

--- a/src/main/java/org/jackhuang/watercraft/util/ReflectionUtil.java
+++ b/src/main/java/org/jackhuang/watercraft/util/ReflectionUtil.java
@@ -4,6 +4,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 public class ReflectionUtil {
+    private ReflectionUtil() {
+    }
+
     public static Field getField(Class<?> clazz, String[] names) {
         for (String name : names) {
             try {

--- a/src/main/java/org/jackhuang/watercraft/util/StackUtil.java
+++ b/src/main/java/org/jackhuang/watercraft/util/StackUtil.java
@@ -20,6 +20,9 @@ public final class StackUtil {
 
     private static final Random random = new Random();
 
+    private StackUtil() {
+    }
+
     public static ItemStack getFromInventory(IInventory inventory, ItemStack itemStackDestination, boolean simulate) {
         ItemStack ret = null;
         int toTransfer = itemStackDestination.stackSize;

--- a/src/main/java/org/jackhuang/watercraft/util/Utils.java
+++ b/src/main/java/org/jackhuang/watercraft/util/Utils.java
@@ -24,6 +24,9 @@ import org.jackhuang.watercraft.WaterPower;
 import org.jackhuang.watercraft.integration.ic2.ICItemFinder;
 
 public class Utils {
+    private Utils() {
+    }
+
     public static <T> T[] concat(T[] first, T[] second) {
         T[] result = Arrays.copyOf(first, first.length + second.length);
         System.arraycopy(second, 0, result, first.length, second.length);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
